### PR TITLE
Add Github Workflow to deploy extension to web store on Github

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Submit Extension To Stores
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.2
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+      - name: Build package
+        run: npm run build:crx
+      - name: Create zip file
+        run: npm run move:crx
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          artifact: ./dist/howdz-dashboard.zip
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/scripts/build-crx.js
+++ b/scripts/build-crx.js
@@ -1,4 +1,12 @@
 const AdmZip = require('adm-zip');
+const fs = require('fs');
+
+// the dist directory might not exist when this script gets invoked (when only `npm run build:crx` has been run)
+const distDir = 'dist'
+if (!fs.existsSync(distDir)){
+  fs.mkdirSync(distDir);
+}
+
 const zip = new AdmZip();
 zip.addLocalFolder('crx');
 zip.writeZip('dist/howdz-dashboard.crx');


### PR DESCRIPTION
Hi @leon-kfd, we created a [Github action](https://github.com/marketplace/actions/browser-plugin-publisher) to make it easier to publish extensions to the various web stores.

Thought you might find it useful so I added a Github workflow that will run the build and move step, and publish to the web store on dispatch.

The only thing you would need to create is a `SUBMIT_KEYS` GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json).

Here's a sample key:

{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "zip": "./extension/chrome.zip",
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "./extension/firefox.xpi",
    "apiKey": "123",
    "apiSecret": "abcd",
    "extId": "foobar"
  }
}

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me.

Otherwise, if this doesn't seem necessary, feel free to close the PR!